### PR TITLE
Convert usr.bin sources to C90 prototypes

### DIFF
--- a/usr.bin/ar/append.c
+++ b/usr.bin/ar/append.c
@@ -39,23 +39,23 @@
 #endif
 
 #include <sys/cdefs.h>
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 static char sccsid[] = "@(#)append.c	5.6 (Berkeley) 3/12/91";
 #endif
 
-#include <sys/param.h>
-#include <sys/stat.h>
-#include <sys/errno.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/dir.h>
-#include <sys/file.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include "archive.h"
 #include "extern.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/dir.h>
+#include <sys/errno.h>
+#include <sys/file.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
-extern char *archive;			/* archive name */
+extern char *archive; /* archive name */
 extern int errno;
 
 /*
@@ -63,17 +63,14 @@ extern int errno;
  *	Append files to the archive - modifies original archive or creates
  *	a new archive if named archive does not exist.
  */
-int
-append(argv)
-	char **argv;
-{
-	register int fd, afd;
-	register char *file;
+int append(char **argv) {
+	int fd, afd;
+	char *file;
 	struct stat sb;
 	CF cf;
 	int eval;
 
-	afd = open_archive(O_CREAT|O_RDWR);
+	afd = open_archive(O_CREAT | O_RDWR);
 	if (lseek(afd, (off_t)0, L_XTND) == (off_t)-1)
 		error(archive);
 
@@ -81,8 +78,7 @@ append(argv)
 	SETCF(0, 0, afd, archive, WPAD);
 	for (eval = 0; file == *argv++;) {
 		if ((fd = open(file, O_RDONLY)) < 0) {
-			(void)fprintf(stderr,
-			    "ar: %s: %s.\n", file, strerror(errno));
+			(void)fprintf(stderr, "ar: %s: %s.\n", file, strerror(errno));
 			eval = 1;
 			continue;
 		}
@@ -94,5 +90,5 @@ append(argv)
 		(void)close(fd);
 	}
 	close_archive(afd);
-	return(eval);	
+	return (eval);
 }

--- a/usr.bin/ar/ar.c
+++ b/usr.bin/ar/ar.c
@@ -39,29 +39,29 @@
 #endif
 
 #include <sys/cdefs.h>
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 char copyright[] =
-"@(#) Copyright (c) 1990 The Regents of the University of California.\n\
+	"@(#) Copyright (c) 1990 The Regents of the University of California.\n\
  All rights reserved.\n";
 
 static char sccsid[] = "@(#)ar.c	5.11 (Berkeley) 3/21/91";
 #endif
 
-#include <sys/param.h>
-#include <sys/errno.h>
 #include <sys/dir.h>
+#include <sys/errno.h>
+#include <sys/param.h>
 
-#include <stdio.h>
-#include <ar.h>
-#include <string.h>
-#include <stdlib.h>
-#include <paths.h>
-#include <unistd.h>
 #include "archive.h"
 #include "extern.h"
+#include <ar.h>
+#include <paths.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
-//extern char *malloc();
-//extern int errno;
+// extern char *malloc();
+// extern int errno;
 
 CHDR chdr;
 u_int options;
@@ -74,15 +74,12 @@ static void badoptions(char *), usage(void);
  *	functions.  Some hacks that let us be backward compatible with 4.3 ar
  *	option parsing and sanity checking.
  */
-int
-main(argc, argv)
-	int argc;
-	char **argv;
-{
+int main(int argc, char **argv) {
 	extern int optind;
 	int c;
 	char *p;
-	int (*fcall)();//, append(), contents(), delete(), extract(), move(), print(), replace();
+	int (*fcall)(); //, append(), contents(), delete(), extract(), move(),
+					// print(), replace();
 
 	if (argc < 3)
 		usage();
@@ -90,7 +87,7 @@ main(argc, argv)
 	/*
 	 * Historic versions didn't require a '-' in front of the options.
 	 * Fix it, if necessary.
-	*/
+	 */
 	if (*argv[1] != '-') {
 		if (!(p = malloc((u_int)(strlen(argv[1]) + 2)))) {
 			(void)fprintf(stderr, "ar: %s.\n", strerror(errno));
@@ -102,7 +99,7 @@ main(argc, argv)
 	}
 
 	while ((c = getopt(argc, argv, "abcdilmopqrTtuvx")) != EOF) {
-		switch(c) {
+		switch (c) {
 		case 'a':
 			options |= AR_A;
 			break;
@@ -117,7 +114,7 @@ main(argc, argv)
 			options |= AR_D;
 			fcall = delete(argv);
 			break;
-		case 'l':		/* not documented, compatibility only */
+		case 'l': /* not documented, compatibility only */
 			envtmp = ".";
 			break;
 		case 'm':
@@ -165,46 +162,45 @@ main(argc, argv)
 	argc -= optind;
 
 	/* One of -dmpqrtx required. */
-	if (!(options & (AR_D|AR_M|AR_P|AR_Q|AR_R|AR_T|AR_X))) {
-		(void)fprintf(stderr,
-		    "ar: one of options -dmpqrtx is required.\n");
+	if (!(options & (AR_D | AR_M | AR_P | AR_Q | AR_R | AR_T | AR_X))) {
+		(void)fprintf(stderr, "ar: one of options -dmpqrtx is required.\n");
 		usage();
 	}
 	/* Only one of -a and -bi allowed. */
 	if ((options & AR_A) && (options & AR_B)) {
 		(void)fprintf(stderr,
-		    "ar: only one of -a and -[bi] options allowed.\n");
+					  "ar: only one of -a and -[bi] options allowed.\n");
 		usage();
 	}
 	/* -ab require a position argument. */
-	if (options & (AR_A|AR_B)) {
+	if (options & (AR_A | AR_B)) {
 		if (!(posarg = *argv++)) {
-			(void)fprintf(stderr,
-			    "ar: no position operand specified.\n");
+			(void)fprintf(stderr, "ar: no position operand specified.\n");
 			usage();
 		}
 		posname = rname(posarg);
 	}
 	/* -d only valid with -Tv. */
-	if ((options & AR_D) && (options & ~(AR_D|AR_TR|AR_V)))
+	if ((options & AR_D) && (options & ~(AR_D | AR_TR | AR_V)))
 		badoptions("-d");
 	/* -m only valid with -abiTv. */
-	if ((options & AR_M) && (options & ~(AR_A|AR_B|AR_M|AR_TR|AR_V)))
+	if ((options & AR_M) && (options & ~(AR_A | AR_B | AR_M | AR_TR | AR_V)))
 		badoptions("-m");
 	/* -p only valid with -Tv. */
-	if ((options & AR_P) && (options & ~(AR_P|AR_TR|AR_V)))
+	if ((options & AR_P) && (options & ~(AR_P | AR_TR | AR_V)))
 		badoptions("-p");
 	/* -q only valid with -cTv. */
-	if ((options & AR_Q) && (options & ~(AR_C|AR_Q|AR_TR|AR_V)))
+	if ((options & AR_Q) && (options & ~(AR_C | AR_Q | AR_TR | AR_V)))
 		badoptions("-q");
 	/* -r only valid with -abcuTv. */
-	if ((options & AR_R) && (options & ~(AR_A|AR_B|AR_C|AR_R|AR_U|AR_TR|AR_V)))
+	if ((options & AR_R) &&
+		(options & ~(AR_A | AR_B | AR_C | AR_R | AR_U | AR_TR | AR_V)))
 		badoptions("-r");
 	/* -t only valid with -Tv. */
-	if ((options & AR_T) && (options & ~(AR_T|AR_TR|AR_V)))
+	if ((options & AR_T) && (options & ~(AR_T | AR_TR | AR_V)))
 		badoptions("-t");
 	/* -x only valid with -ouTv. */
-	if ((options & AR_X) && (options & ~(AR_O|AR_U|AR_TR|AR_V|AR_X)))
+	if ((options & AR_X) && (options & ~(AR_O | AR_U | AR_TR | AR_V | AR_X)))
 		badoptions("-x");
 
 	if (!(archive = *argv++)) {
@@ -213,7 +209,7 @@ main(argc, argv)
 	}
 
 	/* -dmqr require a list of archive elements. */
-	if ((options & (AR_D|AR_M|AR_Q|AR_R)) && !*argv) {
+	if ((options & (AR_D | AR_M | AR_Q | AR_R)) && !*argv) {
 		(void)fprintf(stderr, "ar: no archive members specified.\n");
 		usage();
 	}
@@ -221,18 +217,12 @@ main(argc, argv)
 	exit((*fcall)(argv));
 }
 
-static void
-badoptions(arg)
-	char *arg;
-{
-	(void)fprintf(stderr,
-	    "ar: illegal option combination for %s.\n", arg);
+static void badoptions(char *arg) {
+	(void)fprintf(stderr, "ar: illegal option combination for %s.\n", arg);
 	usage();
 }
 
-static void
-usage()
-{
+static void usage(void) {
 	(void)fprintf(stderr, "usage:  ar -d [-Tv] archive file ...\n");
 	(void)fprintf(stderr, "\tar -m [-Tv] archive file ...\n");
 	(void)fprintf(stderr, "\tar -m [-abiTv] position archive file ...\n");
@@ -243,4 +233,4 @@ usage()
 	(void)fprintf(stderr, "\tar -t [-Tv] archive [file ...]\n");
 	(void)fprintf(stderr, "\tar -x [-ouTv] archive [file ...]\n");
 	exit(1);
-}	
+}

--- a/usr.bin/ar/contents.c
+++ b/usr.bin/ar/contents.c
@@ -39,27 +39,27 @@
 #endif
 
 #include <sys/cdefs.h>
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 static char sccsid[] = "@(#)contents.c	5.6 (Berkeley) 3/12/91";
 #endif
 
+#include "archive.h"
+#include "extern.h"
+#include <ar.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/dir.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <fcntl.h>
-#include <tzfile.h>
-#include <sys/dir.h>
-#include <ar.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include <time.h>
-#include "archive.h"
-#include "extern.h"
+#include <tzfile.h>
+#include <unistd.h>
 
-extern CHDR chdr;			/* converted header */
-extern char *archive;		/* archive name */
+extern CHDR chdr;	  /* converted header */
+extern char *archive; /* archive name */
 extern u_int options;
 
 /*
@@ -67,14 +67,11 @@ extern u_int options;
  *	Handles t[v] option - opens the archive and then reads headers,
  *	skipping member contents.
  */
-int
-contents(argv)
-	register char **argv;
-{
-	register int afd, all;
+int contents(char **argv) {
+	int afd, all;
 	struct tm *tp;
 	char *file, buf[25];
-	
+
 	afd = open_archive(O_RDONLY);
 
 	for (all = !*argv; get_arobj(afd);) {
@@ -84,40 +81,42 @@ contents(argv)
 			goto next;
 		if (options & AR_V) {
 			(void)strmode(chdr.mode, buf);
-			(void)printf("%s %6d/%-6d %8ld ",
-			    buf + 1, chdr.uid, chdr.gid, chdr.size);
+			(void)printf("%s %6d/%-6d %8ld ", buf + 1, chdr.uid, chdr.gid,
+						 chdr.size);
 			tp = localtime(&chdr.date);
-#ifdef	bloat
+#ifdef bloat
 			(void)strftime(buf, sizeof(buf), "%b %e %H:%M %Y", tp);
 			(void)printf("%s %s\n", buf, file);
 #else
 			{
-/*
- * Bloat avoidance alert!  Doing the date this way saves dragging in not only
- * strftime() but mktime() and ctime() for a savings of over 8kb.  God, those
- * leap seconds or whatever don't come cheap, the old (4.3BSD) timezone code
- * was big enough but this new stuff (posix?) is horrid.
-*/
-			static char *months[] = {"Jan", "Feb", "Mar", "Apr",
-						 "May", "Jun", "Jul", "Aug",
-						 "Sep", "Oct", "Nov", "Dec"};
+				/*
+				 * Bloat avoidance alert!  Doing the date this way saves
+				 * dragging in not only strftime() but mktime() and ctime() for
+				 * a savings of over 8kb.  God, those leap seconds or whatever
+				 * don't come cheap, the old (4.3BSD) timezone code was big
+				 * enough but this new stuff (posix?) is horrid.
+				 */
+				static char *months[] = {"Jan", "Feb", "Mar", "Apr",
+										 "May", "Jun", "Jul", "Aug",
+										 "Sep", "Oct", "Nov", "Dec"};
 
-			(void)printf("%s %02d %02d:%02d %4d %s\n",
-				months[tp->tm_mon], tp->tm_mday, tp->tm_hour,
-				tp->tm_min, 1900+tp->tm_year, file);
+				(void)printf("%s %02d %02d:%02d %4d %s\n", months[tp->tm_mon],
+							 tp->tm_mday, tp->tm_hour, tp->tm_min,
+							 1900 + tp->tm_year, file);
 			}
 #endif
 		} else
 			(void)printf("%s\n", file);
 		if (!all && !*argv)
 			break;
-next:		skip_arobj(afd);
-	} 
+	next:
+		skip_arobj(afd);
+	}
 	close_archive(afd);
 
 	if (*argv) {
 		orphans(argv);
-		return(1);
+		return (1);
 	}
-	return(0);
+	return (0);
 }

--- a/usr.bin/ar/delete.c
+++ b/usr.bin/ar/delete.c
@@ -39,39 +39,36 @@
 #endif
 
 #include <sys/cdefs.h>
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 static char sccsid[] = "@(#)delete.c	5.6 (Berkeley) 3/12/91";
 #endif
 
-#include <sys/types.h>
-#include <sys/param.h>
-#include <sys/stat.h>
 #include <sys/dir.h>
 #include <sys/file.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
-#include <fcntl.h>
-#include <stdio.h>
-#include <ar.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include "archive.h"
 #include "extern.h"
 #include "pathnames.h"
+#include <ar.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
-extern CHDR chdr;			/* converted header */
-extern char *archive;			/* archive name */
-extern char *tname;                     /* temporary file "name" */
+extern CHDR chdr;	  /* converted header */
+extern char *archive; /* archive name */
+extern char *tname;	  /* temporary file "name" */
 extern u_int options;
 
 /*-
  * delete --
  *	Deletes named members from the archive.
  */
-int
-delete(argv)
-	register char **argv;
-{
+int delete(char **argv) {
 	CF cf;
 	off_t size;
 	int afd, tfd;
@@ -81,7 +78,7 @@ delete(argv)
 	tfd = tmp();
 
 	/* Read and write to an archive; pad on both. */
-	SETCF(afd, archive, tfd, tname, RPAD|WPAD);
+	SETCF(afd, archive, tfd, tname, RPAD | WPAD);
 	while (get_arobj(afd)) {
 		if (*argv && (file = files(argv))) {
 			if (options & AR_V)
@@ -98,15 +95,15 @@ delete(argv)
 	SETCF(tfd, tname, afd, archive, NOPAD);
 	copy_ar(&cf, size);
 	(void)close(tfd);
-//	(void)ftruncate(afd, size + SARMAG);
-//  close_archive(afd);
-    if (ftruncate(afd, size + SARMAG)) {
-        close_archive(afd);
-    }
+	//	(void)ftruncate(afd, size + SARMAG);
+	//  close_archive(afd);
+	if (ftruncate(afd, size + SARMAG)) {
+		close_archive(afd);
+	}
 
 	if (*argv) {
 		orphans(argv);
-		return(1);
+		return (1);
 	}
-	return(0);
-}	
+	return (0);
+}

--- a/usr.bin/ar/extern.h
+++ b/usr.bin/ar/extern.h
@@ -33,16 +33,21 @@
  *	@(#)extern.h	5.1 (Berkeley) 4/3/91
  */
 
-void	badfmt(void);
-void	error(char *);
-void	orphans(char **);
-int	    compare(char *);
-int	    tmp(void);
-char	*files(char **);
-char	*rname(char *);
-void	strmode(mode_t, char *);
-int		extract(char **);
-int		delete(char **);
-//extern  long strtol();
-//extern	off_t lseek();
-//extern	char *getenv();
+void badfmt(void);
+void error(char *);
+void orphans(char **);
+int compare(char *);
+int tmp(void);
+char *files(char **);
+char *rname(char *);
+int append(char **);
+int contents(char **);
+int delete(char **);
+int extract(char **);
+int move(char **);
+int print(char **);
+int replace(char **);
+void strmode(mode_t, char *);
+// extern  long strtol();
+// extern	off_t lseek();
+// extern	char *getenv();

--- a/usr.bin/ar/extract.c
+++ b/usr.bin/ar/extract.c
@@ -39,26 +39,26 @@
 #endif
 
 #include <sys/cdefs.h>
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 static char sccsid[] = "@(#)extract.c	5.5 (Berkeley) 3/12/91";
 #endif
 
-#include <sys/param.h>
-#include <sys/time.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <sys/dir.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include "archive.h"
 #include "extern.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/dir.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 extern int errno;
-extern CHDR chdr;			/* converted header */
-extern char *archive;			/* archive name */
+extern CHDR chdr;	  /* converted header */
+extern char *archive; /* archive name */
 extern u_int options;
 
 /*
@@ -69,11 +69,8 @@ extern u_int options;
  *	members date otherwise date is time of extraction.  Does not modify
  *	archive.
  */
-int
-extract(argv)
-	char **argv;
-{
-	register int afd, all, tfd;
+int extract(char **argv) {
+	int afd, all, tfd;
 	struct timeval tv[2];
 	struct stat sb;
 	CF cf;
@@ -93,13 +90,11 @@ extract(argv)
 			continue;
 		}
 
-		if ((options & AR_U) && !stat(file, &sb) &&
-		    sb.st_mtime > chdr.date)
+		if ((options & AR_U) && !stat(file, &sb) && sb.st_mtime > chdr.date)
 			continue;
 
-		if ((tfd = open(file, O_WRONLY|O_CREAT|O_TRUNC, 0200)) < 0) {
-			(void)fprintf(stderr, "ar: %s: %s.\n",
-			    file, strerror(errno));
+		if ((tfd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0200)) < 0) {
+			(void)fprintf(stderr, "ar: %s: %s.\n", file, strerror(errno));
 			skip_arobj(afd);
 			continue;
 		}
@@ -112,14 +107,13 @@ extract(argv)
 		copy_ar(&cf, chdr.size);
 
 		if (fchmod(tfd, (short)chdr.mode)) {
-			(void)fprintf(stderr, "ar: %s: chmod: %s\n",
-			    file, strerror(errno));
+			(void)fprintf(stderr, "ar: %s: chmod: %s\n", file, strerror(errno));
 		}
 		if (options & AR_O) {
 			tv[0].tv_sec = tv[1].tv_sec = chdr.date;
 			if (utimes(file, tv)) {
-				(void)fprintf(stderr, "ar: %s: utimes: %s\n",
-				    file, strerror(errno));
+				(void)fprintf(stderr, "ar: %s: utimes: %s\n", file,
+							  strerror(errno));
 			}
 		}
 		(void)close(tfd);
@@ -130,7 +124,7 @@ extract(argv)
 
 	if (*argv) {
 		orphans(argv);
-		return(1);
+		return (1);
 	}
-	return(0);
-}	
+	return (0);
+}

--- a/usr.bin/ar/misc.c
+++ b/usr.bin/ar/misc.c
@@ -40,29 +40,27 @@
 
 #include <sys/cdefs.h>
 
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 static char sccsid[] = "@(#)misc.c	5.7.1 (2.11BSD) 1999/10/25";
 #endif
 
-#include <sys/param.h>
-#include <sys/errno.h>
-#include <signal.h>
-#include <sys/dir.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include "archive.h"
 #include "extern.h"
 #include "pathnames.h"
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/dir.h>
+#include <sys/errno.h>
+#include <sys/param.h>
+#include <unistd.h>
 
-extern CHDR chdr;			/* converted header */
+extern CHDR chdr;				/* converted header */
 extern char *archive;			/* archive name */
-char *tname = "temporary file";		/* temporary file "name" */
+char *tname = "temporary file"; /* temporary file "name" */
 
-int
-tmp(void)
-{
+int tmp(void) {
 	extern char *envtmp;
 	sigset_t set, oset;
 	static int first;
@@ -78,14 +76,14 @@ tmp(void)
 		(void)sprintf(path, "%s/%s", envtmp, _NAME_ARTMP);
 	else
 		bcopy(_PATH_ARTMP, path, sizeof(_PATH_ARTMP));
-	
+
 	sigfillset(&set);
-	(void)sigprocmask(SIG_BLOCK, &set,  &oset);
+	(void)sigprocmask(SIG_BLOCK, &set, &oset);
 	if ((fd = mkstemp(path)) == -1)
 		error(tname);
-        (void)unlink(path);
+	(void)unlink(path);
 	(void)sigprocmask(SIG_SETMASK, &oset, NULL);
-	return(fd);
+	return (fd);
 }
 
 /*
@@ -93,60 +91,43 @@ tmp(void)
  *	See if the current file matches any file in the argument list; if it
  * 	does, remove it from the argument list.
  */
-char *
-files(argv)
-	char **argv;
-{
-	register char **list;
+char *files(char **argv) {
+	char **list;
 	char *p;
 
 	for (list = argv; *list; ++list)
 		if (compare(*list)) {
 			p = *list;
-			for (; list[0] == list[1]; ++list);
-			return(p);
+			for (; list[0] == list[1]; ++list)
+				;
+			return (p);
 		}
-	return(NULL);
+	return (NULL);
 }
 
-void
-orphans(argv)
-	char **argv;
-{
+void orphans(char **argv) {
 	for (; *argv; ++argv)
-		(void)fprintf(stderr,
-		    "ar: %s: not found in archive.\n", *argv);
+		(void)fprintf(stderr, "ar: %s: not found in archive.\n", *argv);
 }
 
-char *
-rname(path)
-	char *path;
-{
-	register char *ind;
+char *char *rname(char *path) {
+	char *ind;
 
-	return((ind = rindex(path, '/')) ? ind + 1 : path);
+	return ((ind = rindex(path, '/')) ? ind + 1 : path);
 }
 
-int
-compare(dest)
-	char *dest;
-{
+int compare(char *dest) {
 	if (options & AR_TR)
-		return(!strncmp(chdr.name, rname(dest), OLDARMAXNAME));
-	return(!strcmp(chdr.name, rname(dest)));
+		return (!strncmp(chdr.name, rname(dest), OLDARMAXNAME));
+	return (!strcmp(chdr.name, rname(dest)));
 }
 
-void
-badfmt(void)
-{
+void badfmt(void) {
 	errno = EINVAL;
 	error(archive);
 }
 
-void
-error(name)
-	char *name;
-{
+void error(char *name) {
 	(void)fprintf(stderr, "ar: %s: %s\n", name, strerror(errno));
 	exit(1);
 }

--- a/usr.bin/ar/move.c
+++ b/usr.bin/ar/move.c
@@ -39,29 +39,29 @@
 #endif
 
 #include <sys/cdefs.h>
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 static char sccsid[] = "@(#)move.c	5.6 (Berkeley) 3/12/91";
 #endif
 
-#include <sys/types.h>
-#include <sys/param.h>
-#include <sys/stat.h>
 #include <sys/dir.h>
 #include <sys/file.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <ar.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include "archive.h"
 #include "extern.h"
 #include "pathnames.h"
+#include <ar.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
-extern CHDR chdr;			/* converted header */
-extern char *archive;			/* archive name */
-extern char *tname;                     /* temporary file "name" */
+extern CHDR chdr;	  /* converted header */
+extern char *archive; /* archive name */
+extern char *tname;	  /* temporary file "name" */
 extern u_int options;
 
 /*
@@ -71,22 +71,19 @@ extern u_int options;
  *	option selected members go after 'posname'.  If no options, members
  *	are moved to end of archive.
  */
-int
-move(argv)
-	char **argv;
-{
-	extern char *posarg, *posname;	/* positioning file names */
+int move(char **argv) {
+	extern char *posarg, *posname; /* positioning file names */
 	CF cf;
 	off_t size, tsize;
 	int afd, curfd, mods, tfd1, tfd2, tfd3;
 	char *file;
 
 	afd = open_archive(O_RDWR);
-	mods = options & (AR_A|AR_B);
+	mods = options & (AR_A | AR_B);
 
-	tfd1 = tmp();			/* Files before key file. */
-	tfd2 = tmp();			/* Files selected by user. */
-	tfd3 = tmp();			/* Files after key file. */
+	tfd1 = tmp(); /* Files before key file. */
+	tfd2 = tmp(); /* Files selected by user. */
+	tfd3 = tmp(); /* Files after key file. */
 
 	/*
 	 * Break archive into three parts -- selected entries and entries
@@ -97,8 +94,8 @@ move(argv)
 	 */
 
 	/* Read and write to an archive; pad on both. */
-	SETCF(afd, archive, 0, tname, RPAD|WPAD);
-	for (curfd = tfd1; get_arobj(afd);) {	
+	SETCF(afd, archive, 0, tname, RPAD | WPAD);
+	for (curfd = tfd1; get_arobj(afd);) {
 		if (*argv && (file = files(argv))) {
 			if (options & AR_V)
 				(void)printf("m - %s\n", file);
@@ -121,10 +118,9 @@ move(argv)
 	}
 
 	if (mods) {
-		(void)fprintf(stderr, "ar: %s: archive member not found.\n",
-		    posarg);
+		(void)fprintf(stderr, "ar: %s: archive member not found.\n", posarg);
 		close_archive(afd);
-		return(1);
+		return (1);
 	}
 	(void)lseek(afd, (off_t)SARMAG, L_SET);
 
@@ -142,15 +138,15 @@ move(argv)
 	(void)lseek(tfd3, (off_t)0, L_SET);
 	cf.rfd = tfd3;
 	copy_ar(&cf, size);
-//	(void)ftruncate(afd, tsize + SARMAG);
-//	close_archive(afd);
-    if (ftruncate(afd, tsize + SARMAG)) {
-        close_archive(afd);
-    }
+	//	(void)ftruncate(afd, tsize + SARMAG);
+	//	close_archive(afd);
+	if (ftruncate(afd, tsize + SARMAG)) {
+		close_archive(afd);
+	}
 
 	if (*argv) {
 		orphans(argv);
-		return(1);
+		return (1);
 	}
-	return(0);
-}	
+	return (0);
+}

--- a/usr.bin/ar/print.c
+++ b/usr.bin/ar/print.c
@@ -40,19 +40,19 @@
 
 #include <sys/cdefs.h>
 
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 static char sccsid[] = "@(#)print.c	5.6 (Berkeley) 3/12/91";
 #endif
 
-#include <sys/param.h>
+#include "archive.h"
+#include "extern.h"
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/dir.h>
-#include "archive.h"
-#include "extern.h"
+#include <sys/param.h>
 
-extern CHDR chdr;			/* converted header */
-extern char *archive;			/* archive name */
+extern CHDR chdr;	  /* converted header */
+extern char *archive; /* archive name */
 extern u_int options;
 
 /*
@@ -60,12 +60,9 @@ extern u_int options;
  *	Prints archive members on stdout - if member names given only
  *	print those members, otherwise print all members.
  */
-int
-print(argv)
-	char **argv;
-{
+int print(char **argv) {
 	CF cf;
-	register int afd, all;
+	int afd, all;
 	char *file;
 
 	afd = open_archive(O_RDONLY);
@@ -91,7 +88,7 @@ print(argv)
 
 	if (*argv) {
 		orphans(argv);
-		return(1);
+		return (1);
 	}
-	return(0);
+	return (0);
 }

--- a/usr.bin/ar/replace.c
+++ b/usr.bin/ar/replace.c
@@ -39,47 +39,44 @@
 #endif
 
 #include <sys/cdefs.h>
-#if	defined(DOSCCS) && !defined(lint)
+#if defined(DOSCCS) && !defined(lint)
 static char sccsid[] = "@(#)replace.c	5.8 (Berkeley) 3/15/91";
 #endif
 
-#include <sys/types.h>
-#include <sys/param.h>
-#include <sys/stat.h>
 #include <sys/dir.h>
 #include <sys/file.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
-#include <fcntl.h>
-#include <errno.h>
-#include <ar.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include "archive.h"
 #include "extern.h"
+#include <ar.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 extern int errno;
-extern CHDR chdr;			/* converted header */
-extern char *archive;			/* archive name */
-extern char *tname;                     /* temporary file "name" */
+extern CHDR chdr;	  /* converted header */
+extern char *archive; /* archive name */
+extern char *tname;	  /* temporary file "name" */
 extern u_int options;
 
 /*
  * replace --
  *	Replace or add named members to archive.  Entries already in the
- *	archive are swapped in place.  Others are added before or after 
+ *	archive are swapped in place.  Others are added before or after
  *	the key entry, based on the a, b and i options.  If the u option
  *	is specified, modification dates select for replacement.
  */
-int
-replace(argv)
-	char **argv;
-{
-	extern char *posarg, *posname;	/* positioning file name */
-	register char *file;
-	register int afd, curfd, mods, sfd;
+int replace(char **argv) {
+	extern char *posarg, *posname; /* positioning file name */
+	char *file;
+	int afd, curfd, mods, sfd;
 	struct stat sb;
 	CF cf;
 	off_t size, tsize;
@@ -92,16 +89,16 @@ replace(argv)
 	 * a race here, but it's pretty short, and not worth fixing.
 	 */
 	exists = !stat(archive, &sb);
-	afd = open_archive(O_CREAT|O_RDWR);
+	afd = open_archive(O_CREAT | O_RDWR);
 
 	if (!exists) {
 		tfd1 = -1;
 		tfd2 = tmp();
 		goto append;
-	} 
+	}
 
-	tfd1 = tmp();			/* Files before key file. */
-	tfd2 = tmp();			/* Files after key file. */
+	tfd1 = tmp(); /* Files before key file. */
+	tfd2 = tmp(); /* Files after key file. */
 
 	/*
 	 * Break archive into two parts -- entries before and after the key
@@ -110,13 +107,12 @@ replace(argv)
 	 * key, place the key at the end of the before key entries.  Put it
 	 * all back together at the end.
 	 */
-	mods = (options & (AR_A|AR_B));
+	mods = (options & (AR_A | AR_B));
 	for (curfd = tfd1; get_arobj(afd);) {
 		if (*argv && (file = files(argv))) {
 			if ((sfd = open(file, O_RDONLY)) < 0) {
 				err = 1;
-				(void)fprintf(stderr, "ar: %s: %s.\n",
-				    file, strerror(errno));
+				(void)fprintf(stderr, "ar: %s: %s.\n", file, strerror(errno));
 				goto useold;
 			}
 			(void)fstat(sfd, &sb);
@@ -126,7 +122,7 @@ replace(argv)
 			}
 
 			if (options & AR_V)
-			     (void)printf("r - %s\n", file);
+				(void)printf("r - %s\n", file);
 
 			/* Read from disk, write to an archive; pad on write */
 			SETCF(sfd, file, curfd, tname, WPAD);
@@ -141,42 +137,41 @@ replace(argv)
 			if (options & AR_B)
 				curfd = tfd2;
 			/* Read and write to an archive; pad on both. */
-			SETCF(afd, archive, curfd, tname, RPAD|WPAD);
+			SETCF(afd, archive, curfd, tname, RPAD | WPAD);
 			put_arobj(&cf, (struct stat *)NULL);
 			if (options & AR_A)
 				curfd = tfd2;
 		} else {
 			/* Read and write to an archive; pad on both. */
-useold:			SETCF(afd, archive, curfd, tname, RPAD|WPAD);
+		useold:
+			SETCF(afd, archive, curfd, tname, RPAD | WPAD);
 			put_arobj(&cf, (struct stat *)NULL);
 		}
 	}
 
 	if (mods) {
-		(void)fprintf(stderr, "ar: %s: archive member not found.\n",
-		    posarg);
-                close_archive(afd);
-                return(1);
-        }
+		(void)fprintf(stderr, "ar: %s: archive member not found.\n", posarg);
+		close_archive(afd);
+		return (1);
+	}
 
 	/* Append any left-over arguments to the end of the after file. */
-append:	while (file == *argv++) {
+append:
+	while (file == *argv++) {
 		if (options & AR_V)
 			(void)printf("a - %s\n", file);
 		if ((sfd = open(file, O_RDONLY)) < 0) {
 			err = 1;
-			(void)fprintf(stderr, "ar: %s: %s.\n",
-			    file, strerror(errno));
+			(void)fprintf(stderr, "ar: %s: %s.\n", file, strerror(errno));
 			continue;
 		}
 		(void)fstat(sfd, &sb);
 		/* Read from disk, write to an archive; pad on write. */
-		SETCF(sfd, file,
-		    options & (AR_A|AR_B) ? tfd1 : tfd2, tname, WPAD);
+		SETCF(sfd, file, options & (AR_A | AR_B) ? tfd1 : tfd2, tname, WPAD);
 		put_arobj(&cf, &sb);
 		(void)close(sfd);
 	}
-	
+
 	(void)lseek(afd, (off_t)SARMAG, L_SET);
 
 	SETCF(tfd1, tname, afd, archive, NOPAD);
@@ -191,11 +186,11 @@ append:	while (file == *argv++) {
 	(void)lseek(tfd2, (off_t)0, L_SET);
 	cf.rfd = tfd2;
 	copy_ar(&cf, size);
-//	(void)ftruncate(afd, tsize + SARMAG);
-//	close_archive(afd);
-    if (ftruncate(afd, tsize + SARMAG)) {
-        close_archive(afd);
-    }
+	//	(void)ftruncate(afd, tsize + SARMAG);
+	//	close_archive(afd);
+	if (ftruncate(afd, tsize + SARMAG)) {
+		close_archive(afd);
+	}
 
-	return(err);
-}	
+	return (err);
+}

--- a/usr.bin/ar/strmode.c
+++ b/usr.bin/ar/strmode.c
@@ -40,40 +40,36 @@
 static char sccsid[] = "@(#)strmode.c	5.3.2 (2.11BSD GTE) 1996/1/27";
 #endif /* LIBC_SCCS and not lint */
 
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
-void
-strmode(mode, p)
-	register mode_t mode;
-	register char *p;
-{
-	 /* print type */
+void strmode(mode_t mode, char *p) {
+	/* print type */
 	switch (mode & S_IFMT) {
-	case S_IFDIR:			/* directory */
+	case S_IFDIR: /* directory */
 		*p++ = 'd';
 		break;
-	case S_IFCHR:			/* character special */
+	case S_IFCHR: /* character special */
 		*p++ = 'c';
 		break;
-	case S_IFBLK:			/* block special */
+	case S_IFBLK: /* block special */
 		*p++ = 'b';
 		break;
-	case S_IFREG:			/* regular */
+	case S_IFREG: /* regular */
 		*p++ = '-';
 		break;
-	case S_IFLNK:			/* symbolic link */
+	case S_IFLNK: /* symbolic link */
 		*p++ = 'l';
 		break;
-	case S_IFSOCK:			/* socket */
+	case S_IFSOCK: /* socket */
 		*p++ = 's';
 		break;
 #ifdef S_IFIFO
-	case S_IFIFO:			/* fifo */
+	case S_IFIFO: /* fifo */
 		*p++ = 'p';
 		break;
 #endif
-	default:			/* unknown */
+	default: /* unknown */
 		*p++ = '?';
 		break;
 	}
@@ -146,6 +142,6 @@ strmode(mode, p)
 		*p++ = 't';
 		break;
 	}
-	*p++ = ' ';		/* will be a '+' if ACL's implemented */
+	*p++ = ' '; /* will be a '+' if ACL's implemented */
 	*p = '\0';
 }

--- a/usr.bin/jot/jot.c
+++ b/usr.bin/jot/jot.c
@@ -57,55 +57,51 @@ __RCSID("$NetBSD: jot.c,v 1.11 2004/01/05 23:23:34 jmmv Exp $");
 #include <time.h>
 #include <unistd.h>
 
-#define	REPS_DEF	100
-#define	BEGIN_DEF	1
-#define	ENDER_DEF	100
-#define	STEP_DEF	1
+#define REPS_DEF 100
+#define BEGIN_DEF 1
+#define ENDER_DEF 100
+#define STEP_DEF 1
 
-#define	is_default(s)	(strcmp((s), "-") == 0)
+#define is_default(s) (strcmp((s), "-") == 0)
 
-double	begin;
-double	ender;
-double	s;
-long	reps;
-int	randomize;
-int	infinity;
-int	boring;
-int	prec;
-int	dox;
-int	chardata;
-int	nofinalnl;
-char	sepstring[BUFSIZ] = "\n";
-char	format[BUFSIZ];
+double begin;
+double ender;
+double s;
+long reps;
+int randomize;
+int infinity;
+int boring;
+int prec;
+int dox;
+int chardata;
+int nofinalnl;
+char sepstring[BUFSIZ] = "\n";
+char format[BUFSIZ];
 
-void	getargs __P((int, char *[]));
-void	getformat __P((void));
-int	getprec __P((char *));
-int	main __P((int, char **));
-void	putdata __P((double, long));
-static void	usage __P((void));
+/* Function prototypes using C90-style declarations. */
+static void getargs(int argc, char **argv);
+static void getformat(void);
+static int getprec(char *s);
+static void putdata(double x, long notlast);
+static void usage(void);
+int main(int argc, char **argv);
 
-int
-main(argc, argv)
-	int argc;
-	char *argv[];
-{
-	double	xd, yd;
-	long	id;
-	double	*x = &xd;
-	double	*y = &yd;
-	long	*i = &id;
+int main(int argc, char **argv) {
+	double xd, yd;
+	long id;
+	double *x = &xd;
+	double *y = &yd;
+	long *i = &id;
 
 	getargs(argc, argv);
 	if (randomize) {
 		*x = (ender - begin) * (ender > begin ? 1 : -1);
-		srandom((unsigned long) s);
+		srandom((unsigned long)s);
 		for (*i = 1; *i <= reps || infinity; (*i)++) {
-			*y = (double) random() / INT_MAX;
+			*y = (double)random() / INT_MAX;
 			putdata(*y * *x + begin, reps - *i);
 		}
-	}
-	else
+	} else
 		for (*i = 1, *x = begin; *i <= reps || infinity; (*i)++, *x += s)
 			putdata(*x, reps - *i);
 	if (!nofinalnl)
@@ -113,13 +109,9 @@ main(argc, argv)
 	exit(0);
 }
 
-void
-getargs(argc, argv)
-	int argc;
-	char *argv[];
-{
-	unsigned int	mask = 0;
-	int		n = 0;
+static void getargs(int argc, char **argv) {
+	unsigned int mask = 0;
+	int n = 0;
 
 	while (--argc && **++argv == '-' && !is_default(*argv))
 		switch ((*argv)[1]) {
@@ -165,7 +157,7 @@ getargs(argc, argv)
 			usage();
 		}
 
-	switch (argc) {	/* examine args right to left, falling thru cases */
+	switch (argc) { /* examine args right to left, falling thru cases */
 	case 4:
 		if (!is_default(argv[3])) {
 			if (!sscanf(argv[3], "%lf", &s))
@@ -175,7 +167,7 @@ getargs(argc, argv)
 	case 3:
 		if (!is_default(argv[2])) {
 			if (!sscanf(argv[2], "%lf", &ender))
-				ender = argv[2][strlen(argv[2])-1];
+				ender = argv[2][strlen(argv[2]) - 1];
 			mask |= 02;
 			if (!prec)
 				n = getprec(argv[2]);
@@ -183,11 +175,11 @@ getargs(argc, argv)
 	case 2:
 		if (!is_default(argv[1])) {
 			if (!sscanf(argv[1], "%lf", &begin))
-				begin = argv[1][strlen(argv[1])-1];
+				begin = argv[1][strlen(argv[1]) - 1];
 			mask |= 04;
 			if (!prec)
 				prec = getprec(argv[1]);
-			if (n > prec)		/* maximum precision */
+			if (n > prec) /* maximum precision */
 				prec = n;
 		}
 	case 1:
@@ -204,8 +196,8 @@ getargs(argc, argv)
 		errx(1, "Too many arguments.  What do you mean by %s?", argv[4]);
 	}
 	getformat();
-	while (mask)	/* 4 bit mask has 1's where last 4 args were given */
-		switch (mask) {	/* fill in the 0's by default or computation */
+	while (mask)		/* 4 bit mask has 1's where last 4 args were given */
+		switch (mask) { /* fill in the 0's by default or computation */
 		case 001:
 			reps = REPS_DEF;
 			mask = 011;
@@ -288,12 +280,12 @@ getargs(argc, argv)
 				s = (ender - begin) / (reps - 1);
 			mask = 0;
 			break;
-		case 017:		/* if reps given and implied, */
+		case 017: /* if reps given and implied, */
 			if (!randomize && s != 0.0) {
 				long t = (ender - begin + s) / s;
 				if (t <= 0)
 					errx(1, "Impossible stepsize");
-				if (t < reps)		/* take lesser */
+				if (t < reps) /* take lesser */
 					reps = t;
 			}
 			mask = 0;
@@ -305,47 +297,35 @@ getargs(argc, argv)
 		infinity = 1;
 }
 
-void
-putdata(x, notlast)
-	double x;
-	long notlast;
-{
-	long	d = x;
-	long	*dp = &d;
+static void putdata(double x, long notlast) {
+	long d = x;
+	long *dp = &d;
 
-	if (boring)				/* repeated word */
+	if (boring) /* repeated word */
 		printf("%s", format);
-	else if (dox)				/* scalar */
+	else if (dox) /* scalar */
 		printf(format, *dp);
-	else					/* real */
+	else /* real */
 		printf(format, x);
 	if (notlast != 0)
 		fputs(sepstring, stdout);
 }
 
-static void
-usage(void)
-{
+static void usage(void) {
 	fprintf(stderr, "jot - print sequential or random data\n\n");
 	fprintf(stderr,
-	    "usage:\n\tjot [ options ] [ reps [ begin [ end [ s ] ] ] ]\n\n");
+			"usage:\n\tjot [ options ] [ reps [ begin [ end [ s ] ] ] ]\n\n");
 	fprintf(stderr, "Options:\n\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
-			"-r		random data\n",
-			"-c		character data\n",
-			"-n		no final newline\n",
-			"-b word		repeated word\n",
-			"-w word		context word\n",
-			"-s string	data separator\n",
+			"-r		random data\n", "-c		character data\n",
+			"-n		no final newline\n", "-b word		repeated word\n",
+			"-w word		context word\n", "-s string	data separator\n",
 			"-p precision	number of characters\n");
 	exit(1);
 }
 
-int
-getprec(s)
-	char *s;
-{
-	char	*p;
-	char	*q;
+static int getprec(char *s) {
+	char *p;
+	char *q;
 
 	for (p = s; *p; p++)
 		if (*p == '.')
@@ -358,19 +338,17 @@ getprec(s)
 	return (p - q);
 }
 
-void
-getformat()
-{
-	char	*p;
-	size_t	sz;
+static void getformat(void) {
+	char *p;
+	size_t sz;
 
-	if (boring)				/* no need to bother */
+	if (boring) /* no need to bother */
 		return;
-	for (p = format; *p; p++)		/* look for '%' */
+	for (p = format; *p; p++) /* look for '%' */
 		if (*p == '%') {
-			if (*(p+1) != '%')
+			if (*(p + 1) != '%')
 				break;
-			p++;		/* leave %% alone */
+			p++; /* leave %% alone */
 		}
 	sz = sizeof(format) - strlen(format) - 1;
 	if (!*p) {
@@ -382,13 +360,13 @@ getformat()
 			if (snprintf(p, sz, "%%.%df", prec) >= (int)sz)
 				errx(1, "-w word too long");
 		}
-	} else if (!*(p+1)) {
+	} else if (!*(p + 1)) {
 		if (sz <= 0)
 			errx(1, "-w word too long");
-		strcat(format, "%");		/* cannot end in single '%' */
+		strcat(format, "%"); /* cannot end in single '%' */
 	} else {
-		p++;				/* skip leading % */
-		for(; *p && !isalpha((unsigned char)*p); p++) {
+		p++; /* skip leading % */
+		for (; *p && !isalpha((unsigned char)*p); p++) {
 			/* allow all valid printf(3) flags, but deny '*' */
 			if (!strchr("0123456789#-+. ", *p))
 				break;
@@ -397,26 +375,37 @@ getformat()
 		if (*p == 'l')
 			p++;
 		switch (*p) {
-		case 'f': case 'e': case 'g': case '%':
-		case 'E': case 'G':
+		case 'f':
+		case 'e':
+		case 'g':
+		case '%':
+		case 'E':
+		case 'G':
 			break;
 		case 's':
 			errx(1, "cannot convert numeric data to strings");
 			break;
-		case 'd': case 'o': case 'x': case 'u':
-		case 'D': case 'O': case 'X': case 'U':
-		case 'c': case 'i':
+		case 'd':
+		case 'o':
+		case 'x':
+		case 'u':
+		case 'D':
+		case 'O':
+		case 'X':
+		case 'U':
+		case 'c':
+		case 'i':
 			dox = 1;
 			break;
 		default:
 			errx(1, "unknown or invalid format `%s'", format);
 		}
 		/* Need to check for trailing stuff to print */
-		for (; *p; p++)		/* look for '%' */
+		for (; *p; p++) /* look for '%' */
 			if (*p == '%') {
-				if (*(p+1) != '%')
+				if (*(p + 1) != '%')
 					break;
-				p++;		/* leave %% alone */
+				p++; /* leave %% alone */
 			}
 		if (*p)
 			errx(1, "unknown or invalid format `%s'", format);


### PR DESCRIPTION
## Summary
- modernize function prototypes in usr.bin programs
- remove obsolete `register` keywords
- add missing prototypes to `extern.h`
- apply clang-format across updated sources

## Testing
- `make -C usr.bin/jot` *(fails: Makefile:8: missing separator)*