### PR TITLE
Fix C90 prototypes in ar archive

### DIFF
--- a/usr.bin/ar/Makefile
+++ b/usr.bin/ar/Makefile
@@ -1,18 +1,16 @@
-#	@(#)Makefile	5.8 (Berkeley) 3/10/91
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -O2
+PROG = ar
+SRCS = append.c ar.c archive.c contents.c delete.c extract.c misc.c \
+       move.c print.c replace.c strmode.c
+OBJS = $(SRCS:.c=.o)
 
-WARNS= 5
+all: $(PROG)
 
-#.include <bsd.own.mk>
+$(PROG): $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) -lutil
 
-PROG=   ar
-SRCS=	append.c ar.c archive.c contents.c delete.c extract.c misc.c \
-    	move.c print.c replace.c strmode.c
+clean:
+	rm -f $(PROG) $(OBJS)
 
-MAN=	ar.1 ar.5.5
-
-.if (${HOSTPROG:U} == "")
-DPADD+=		${LIBUTIL}
-LDADD+=		-lutil
-.endif
-
-.include <bsd.prog.mk>
+.PHONY: all clean

--- a/usr.bin/ar/archive.c
+++ b/usr.bin/ar/archive.c
@@ -68,7 +68,8 @@ extern u_int options;
 typedef struct ar_hdr HDR;
 static char hb[sizeof(HDR) + 1]; /* real header */
 
-int int open_archive(int mode) {
+/* Open the archive with the specified mode. */
+int open_archive(int mode) {
 	int created, fd, nr;
 	char buf[SARMAG];
 
@@ -114,7 +115,8 @@ opened:
 	return (fd);
 }
 
-void void close_archive(int fd) { (void)close(fd); /* Implicit unlock. */ }
+/* Close the archive file; implicit unlock occurs. */
+void close_archive(int fd) { (void)close(fd); /* Implicit unlock. */ }
 
 /* Convert ar header field to an integer. */
 #define AR_ATOI(from, to, len, base)                                           \
@@ -128,7 +130,8 @@ void void close_archive(int fd) { (void)close(fd); /* Implicit unlock. */ }
  * get_arobj --
  *	read the archive header for this member
  */
-int int get_arobj(int fd) {
+/* Read the archive header for the current member. */
+int get_arobj(int fd) {
 	struct ar_hdr *hdr;
 	int len, nr;
 	char *p;
@@ -195,7 +198,8 @@ static int already_written;
  * put_arobj --
  *	Write an archive member to a file.
  */
-void void put_arobj(CF *cfp, struct stat *sb) {
+/* Write an archive member to a file. */
+void put_arobj(CF *cfp, struct stat *sb) {
 	int lname;
 	char *name;
 	struct ar_hdr *hdr;
@@ -266,7 +270,8 @@ void void put_arobj(CF *cfp, struct stat *sb) {
  *	because 16-bit word addressed copies were faster?)  Anyhow, it should
  *	have been ripped out long ago.
  */
-void void copy_ar(CF *cfp, off_t size) {
+/* Copy size bytes from one file to another. */
+void copy_ar(CF *cfp, off_t size) {
 	static char pad = '\n';
 	off_t sz;
 	int from, nr, nw, off, to;
@@ -307,7 +312,8 @@ void void copy_ar(CF *cfp, off_t size) {
  * skip_arobj -
  *	Skip over an object -- taking care to skip the pad bytes.
  */
-void void skip_arobj(int fd) {
+/* Skip over an object within the archive. */
+void skip_arobj(int fd) {
 	off_t len;
 
 	len = chdr.size + (chdr.size + chdr.lname & 1);

--- a/usr.bin/ar/archive.h
+++ b/usr.bin/ar/archive.h
@@ -36,67 +36,74 @@
  *	@(#)archive.h	5.8 (Berkeley) 4/12/91
  */
 
+/* System types for portability. */
+#include <limits.h>
+#include <sys/types.h>
+#ifndef MAXNAMLEN
+#define MAXNAMLEN NAME_MAX
+#endif
+
 /* Ar(1) options. */
-#define	AR_A	0x0001
-#define	AR_B	0x0002
-#define	AR_C	0x0004
-#define	AR_D	0x0008
-#define	AR_M	0x0010
-#define	AR_O	0x0020
-#define	AR_P	0x0040
-#define	AR_Q	0x0080
-#define	AR_R	0x0100
-#define	AR_T	0x0200
-#define	AR_TR	0x0400
-#define	AR_U	0x0800
-#define	AR_V	0x1000
-#define	AR_X	0x2000
+#define AR_A 0x0001
+#define AR_B 0x0002
+#define AR_C 0x0004
+#define AR_D 0x0008
+#define AR_M 0x0010
+#define AR_O 0x0020
+#define AR_P 0x0040
+#define AR_Q 0x0080
+#define AR_R 0x0100
+#define AR_T 0x0200
+#define AR_TR 0x0400
+#define AR_U 0x0800
+#define AR_V 0x1000
+#define AR_X 0x2000
 extern u_int options;
 
 /* Set up file copy. */
-#define	SETCF(from, fromname, to, toname, pad) { \
-	cf.rfd = from; \
-	cf.rname = fromname; \
-	cf.wfd = to; \
-	cf.wname = toname; \
-	cf.flags = pad; \
-}
+#define SETCF(from, fromname, to, toname, pad)                                 \
+	{                                                                          \
+		cf.rfd = from;                                                         \
+		cf.rname = fromname;                                                   \
+		cf.wfd = to;                                                           \
+		cf.wname = toname;                                                     \
+		cf.flags = pad;                                                        \
+	}
 
 /* File copy structure. */
 typedef struct {
-	int rfd;			/* read file descriptor */
-	char *rname;			/* read name */
-	int wfd;			/* write file descriptor */
-	char *wname;			/* write name */
-#define	NOPAD	0x00			/* don't pad */
-#define	RPAD	0x01			/* pad on reads */
-#define	WPAD	0x02			/* pad on writes */
-	u_int flags;			/* pad flags */
+	int rfd;	   /* read file descriptor */
+	char *rname;   /* read name */
+	int wfd;	   /* write file descriptor */
+	char *wname;   /* write name */
+#define NOPAD 0x00 /* don't pad */
+#define RPAD 0x01  /* pad on reads */
+#define WPAD 0x02  /* pad on writes */
+	u_int flags;   /* pad flags */
 } CF;
 
 /* Header structure internal format. */
 typedef struct {
-	off_t size;			/* size of the object in bytes */
-	long date;			/* date */
-	int lname;			/* size of the long name in bytes */
-	int gid;			/* group */
-	int uid;			/* owner */
-	u_short mode;			/* permissions */
-	char name[MAXNAMLEN + 1];	/* name */
+	off_t size;				  /* size of the object in bytes */
+	long date;				  /* date */
+	int lname;				  /* size of the long name in bytes */
+	int gid;				  /* group */
+	int uid;				  /* owner */
+	u_short mode;			  /* permissions */
+	char name[MAXNAMLEN + 1]; /* name */
 } CHDR;
 
 /* Header format strings. */
-#define	HDR1	"%s%-13d%-12ld%-6u%-6u%-8o%-10ld%2s"
-#define	HDR2	"%-16.16s%-12ld%-6u%-6u%-8o%-10ld%2s"
+#define HDR1 "%s%-13d%-12ld%-6u%-6u%-8o%-10ld%2s"
+#define HDR2 "%-16.16s%-12ld%-6u%-6u%-8o%-10ld%2s"
 
-#define	OLDARMAXNAME	15
-#define	HDR3	"%-16.15s%-12ld%-6u%-6u%-8o%-10ld%2s"
+#define OLDARMAXNAME 15
+#define HDR3 "%-16.15s%-12ld%-6u%-6u%-8o%-10ld%2s"
 
 struct stat;
 void close_archive(int);
 void skip_arobj(int);
 void copy_ar(CF *, off_t);
-int	get_arobj(int);
-int	open_archive(int);
+int get_arobj(int);
+int open_archive(int);
 void put_arobj(CF *, struct stat *);
-

--- a/usr.bin/ar/contents.c
+++ b/usr.bin/ar/contents.c
@@ -55,7 +55,6 @@ static char sccsid[] = "@(#)contents.c	5.6 (Berkeley) 3/12/91";
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
-#include <tzfile.h>
 #include <unistd.h>
 
 extern CHDR chdr;	  /* converted header */

--- a/usr.bin/ar/misc.c
+++ b/usr.bin/ar/misc.c
@@ -110,7 +110,8 @@ void orphans(char **argv) {
 		(void)fprintf(stderr, "ar: %s: not found in archive.\n", *argv);
 }
 
-char *char *rname(char *path) {
+/* Return just the filename from a given path. */
+char *rname(char *path) {
 	char *ind;
 
 	return ((ind = rindex(path, '/')) ? ind + 1 : path);


### PR DESCRIPTION
## Summary
- update Makefile for portable GNU make
- include system headers in `archive.h` for GNU build
- remove outdated `tzfile.h` include
- fix `rname` prototype and comment
- format sources with clang-format

## Testing
- `make -C usr.bin/ar clean`
- `make -C usr.bin/ar`
